### PR TITLE
Sprint 3: interfaz de usuario básica

### DIFF
--- a/docs/sprint3_technical_docs.md
+++ b/docs/sprint3_technical_docs.md
@@ -1,0 +1,37 @@
+# Sprint 3: Interfaz de Usuario - Documentación Técnica
+
+## 📋 Resumen Ejecutivo
+El **Sprint 3** añade una capa de interacción sencilla que permite al
+usuario explorar los presets disponibles y generar modelos a partir de
+ellos.  Esta interfaz en modo texto sirve como base para una futura GUI
+en FreeCAD.
+
+## 🏗️ Componentes Implementados
+
+### `ui/user_interface.py`
+- Clase ``UserInterface`` que encapsula a ``DataManager``.
+- Métodos para listar tamaños y DN disponibles.
+- Método ``generate_model`` que invoca a ``FerruleGenerator`` o
+  ``GasketGenerator`` según el componente solicitado.
+
+## 🔧 Ejemplo de Uso
+```python
+from ui.user_interface import UserInterface
+
+ui = UserInterface()
+print(ui.list_available_sizes())      # [1.5, 2.0, ..., 12.0]
+model = ui.generate_model('ferrule', 3.0)
+print(model['name'])                  # 'Ferrule_3.0in_DN80'
+```
+
+## 🧪 Tests
+- ``tests/test_user_interface.py`` valida la lista de tamaños y DN,
+  así como la generación de modelos y el manejo de errores.
+
+## 🔮 Próximos Pasos
+- Reemplazar esta interfaz de texto por diálogos de FreeCAD.
+- Añadir controles gráficos para selección de parámetros.
+- Integrar con un ``Workbench`` dedicado.
+
+---
+**Documento generado**: 18 de Agosto 2025

--- a/tests/test_user_interface.py
+++ b/tests/test_user_interface.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Tests para la interfaz de usuario del Sprint 3."""
+import os
+import sys
+
+import pytest
+
+# Añadir la ruta raíz para importaciones
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ui.user_interface import UserInterface
+
+
+def test_listar_tamanos_y_dns():
+    ui = UserInterface()
+    tamanos = ui.list_available_sizes('ferrule')
+    assert 1.5 in tamanos and 3.0 in tamanos
+    dns = ui.list_available_dns('gasket')
+    assert 'DN40' in dns and 'DN80' in dns
+
+
+def test_generar_modelo_ferrule():
+    ui = UserInterface()
+    geometry = ui.generate_model('ferrule', 3.0)
+    assert geometry['name'] == 'Ferrule_3.0in_DN80'
+    params = geometry['parameters']
+    assert params['Size'] == 3.0
+    assert params['DN'] == 'DN80'
+
+
+def test_generar_modelo_gasket():
+    ui = UserInterface()
+    geometry = ui.generate_model('gasket', 3.0)
+    assert geometry['name'] == 'Gasket_3.0in_DN80'
+    params = geometry['parameters']
+    assert params['Size'] == 3.0
+    assert params['DN'] == 'DN80'
+
+
+def test_error_tamano_inexistente():
+    ui = UserInterface()
+    with pytest.raises(ValueError):
+        ui.generate_model('ferrule', 999)
+

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Paquete de interfaz de usuario para TriptaFittings."""

--- a/ui/user_interface.py
+++ b/ui/user_interface.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Interfaz de usuario simple para TriptaFittings.
+
+Esta interfaz de texto permite a los usuarios consultar los presets
+ disponibles y generar modelos mediante los generadores implementados en
+ los sprints previos.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from models.data_manager import DataManager
+from models.ferrule_generator import FerruleGenerator
+from models.gasket_generator import GasketGenerator
+
+
+class UserInterface:
+    """Capa ligera para interactuar con el sistema.
+
+    Encapsula a ``DataManager`` y expone métodos de alto nivel que pueden
+    ser utilizados por una futura interfaz gráfica.  Esta implementación
+    es intencionalmente mínima para validar el flujo de trabajo del
+    **Sprint 3** sin depender de FreeCAD.
+    """
+
+    def __init__(self, data_directory: Optional[str] = None) -> None:
+        self._manager = DataManager(data_directory)
+        # Cargar todos los datos al inicializar la interfaz.
+        self._manager.load_all_data()
+
+    def list_available_sizes(self, component: str | None = None) -> List[float]:
+        """Retorna los tamaños disponibles para el componente indicado."""
+        return self._manager.get_available_sizes(component)
+
+    def list_available_dns(self, component: str | None = None) -> List[str]:
+        """Retorna los DN disponibles para el componente indicado."""
+        return self._manager.get_available_dns(component)
+
+    def generate_model(self, component: str, size: float) -> Dict[str, Any]:
+        """Genera la geometría para un tamaño y componente específicos.
+
+        Parameters
+        ----------
+        component:
+            ``"ferrule"`` o ``"gasket"``.
+        size:
+            Tamaño del preset en pulgadas.
+        Returns
+        -------
+        Dict[str, Any]
+            Representación simplificada del modelo.
+        Raises
+        ------
+        ValueError
+            Si el componente es inválido o el tamaño no existe.
+        """
+        preset = self._manager.get_preset_by_size(component, size)
+        if preset is None:
+            raise ValueError(
+                f"No se encontró preset para {component} con tamaño {size}"
+            )
+
+        kind = component.lower()
+        if kind == "ferrule":
+            generator = FerruleGenerator(preset)
+        elif kind == "gasket":
+            generator = GasketGenerator(preset)
+        else:  # pragma: no cover - validación redundante
+            raise ValueError(f"Tipo de componente inválido: {component}")
+
+        return generator.generate_geometry()


### PR DESCRIPTION
Resumen:
- Se creó una clase para consultar tamaños y generar modelos.
- Se añadió documentación técnica del sprint.

Pruebas:
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68a4068994bc8321a4fe72b232112157