### PR TITLE
Integrate workbench for sprint 4

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Inicialización del Workbench de TriptaFittings.
+
+Este módulo define la clase ``TriptaFittingsWorkbench`` que FreeCAD
+utilizaría para registrar el workbench.  Se implementa una versión
+simplificada para permitir pruebas unitarias sin depender de la API
+de FreeCAD.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from TriptaFittingsGui import WB_ICON, list_toolbar_commands
+from TriptaFittingsCmd import COMMANDS
+
+
+class TriptaFittingsWorkbench:
+    """Workbench mínimo compatible con la API de FreeCAD."""
+
+    # Metadatos mostrados por FreeCAD
+    MenuText = "TriptaFittings"
+    ToolTip = "Generador de fittings sanitarios"
+    Icon = WB_ICON
+
+    def __init__(self) -> None:
+        self.commands: List[str] = []
+        self.toolbar: List[str] = []
+        self.menu: List[str] = []
+
+    def Initialize(self) -> List[str]:
+        """Inicializa el workbench registrando los comandos disponibles."""
+        self.commands = list(COMMANDS.keys())
+        toolbar_cmds = list_toolbar_commands()
+        self.toolbar.extend(toolbar_cmds)
+        self.menu.extend(toolbar_cmds)
+        # En FreeCAD se registrarían los comandos con Gui.addCommand
+        return self.commands
+
+    def Activated(self) -> None:  # pragma: no cover - comportamiento vacío
+        """Se llama cuando el workbench se activa en FreeCAD."""
+        return None
+
+    def Deactivated(self) -> None:  # pragma: no cover - comportamiento vacío
+        """Se llama cuando el workbench se desactiva."""
+        return None
+
+    def GetClassName(self) -> str:
+        """Nombre de clase usado por FreeCAD para identificar el WB."""
+        return "Gui::PythonWorkbench"
+
+
+# Normalmente FreeCAD invocaría Gui.addWorkbench(TriptaFittingsWorkbench())
+# pero se omite para evitar dependencias durante las pruebas.

--- a/TriptaFittingsCmd.py
+++ b/TriptaFittingsCmd.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Definición de comandos para el workbench TriptaFittings.
+
+Los comandos siguen la estructura habitual de FreeCAD, pero se
+implementan de manera simplificada para permitir su prueba sin la
+presencia del propio FreeCAD.
+"""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from ui.user_interface import UserInterface
+from TriptaFittingsGui import WB_ICON
+
+
+class _BaseCreateCommand:
+    """Comando base que genera un modelo usando :class:`UserInterface`."""
+
+    def __init__(self, component: str) -> None:
+        self.component = component
+        self.ui = UserInterface()
+
+    # Métodos esperados por FreeCAD
+    def Activated(self) -> Dict[str, Any]:  # pragma: no cover - simple wrapper
+        """Ejecuta la generación del modelo con un tamaño de ejemplo."""
+        # Para propósitos de prueba utilizamos un tamaño fijo de 3.0"
+        return self.ui.generate_model(self.component, 3.0)
+
+    def GetResources(self) -> Dict[str, str]:
+        """Recursos gráficos y metadatos del comando."""
+        name = self.component.capitalize()
+        return {
+            "MenuText": f"Create {name}",
+            "ToolTip": f"Genera un modelo de {name}",
+            "Pixmap": WB_ICON,
+        }
+
+
+class CreateFerruleCommand(_BaseCreateCommand):
+    def __init__(self) -> None:
+        super().__init__("ferrule")
+
+
+class CreateGasketCommand(_BaseCreateCommand):
+    def __init__(self) -> None:
+        super().__init__("gasket")
+
+
+COMMANDS = {
+    "Tripta_CreateFerrule": CreateFerruleCommand(),
+    "Tripta_CreateGasket": CreateGasketCommand(),
+}

--- a/TriptaFittingsGui.py
+++ b/TriptaFittingsGui.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Utilidades gráficas para el workbench de TriptaFittings.
+
+Este módulo centraliza rutas de recursos e información relacionada
+con la interfaz gráfica.  Está diseñado para operar incluso en
+entornos donde FreeCAD no está disponible, lo que permite ejecutar
+las pruebas unitarias en un entorno puro de Python.
+"""
+from __future__ import annotations
+
+import os
+from typing import List
+
+# Directorio base del módulo (raíz del paquete)
+MODULE_DIR = os.path.dirname(__file__)
+
+# Ruta al ícono principal del workbench
+WB_ICON = os.path.join(MODULE_DIR, "resources", "triptafittings.svg")
+
+# Comandos que se mostrarán tanto en la toolbar como en el menú
+TOOLBAR_COMMANDS: List[str] = [
+    "Tripta_CreateFerrule",
+    "Tripta_CreateGasket",
+]
+
+
+def list_toolbar_commands() -> List[str]:
+    """Retorna la lista de comandos disponibles para la toolbar."""
+    return list(TOOLBAR_COMMANDS)

--- a/docs/sprint4_technical_docs.md
+++ b/docs/sprint4_technical_docs.md
@@ -1,0 +1,51 @@
+# Sprint 4: Integración con FreeCAD Workbench - Documentación Técnica
+
+## 📋 Resumen Ejecutivo
+El **Sprint 4** introduce la estructura necesaria para que el plugin se
+comporte como un *workbench* de FreeCAD.  Aunque las pruebas se
+realizan en un entorno aislado sin FreeCAD, los módulos creados siguen
+la misma interfaz que utilizaría la aplicación real.
+
+## 🏗️ Componentes Implementados
+
+### `TriptaFittingsGui.py`
+- Define la ruta del ícono principal del workbench.
+- Expone la lista de comandos que se añaden a la toolbar y al menú.
+
+### `TriptaFittingsCmd.py`
+- Implementa los comandos ``CreateFerrule`` y ``CreateGasket``.
+- Cada comando utiliza la ``UserInterface`` para generar un modelo de
+  ejemplo con tamaño ``3.0"``.
+- Provee metadatos mediante ``GetResources`` compatibles con FreeCAD.
+
+### `InitGui.py`
+- Define la clase ``TriptaFittingsWorkbench`` que FreeCAD utilizaría
+  para registrar el workbench.
+- El método ``Initialize`` registra los comandos y prepara las listas de
+  toolbar y menú.
+- Incluye métodos ``Activated`` y ``Deactivated`` como stubs.
+
+### `resources/triptafittings.svg`
+- Ícono vectorial utilizado tanto por el workbench como por los
+  comandos.
+
+## 🔧 Ejemplo de Uso
+```python
+from InitGui import TriptaFittingsWorkbench
+wb = TriptaFittingsWorkbench()
+commands = wb.Initialize()
+print(commands)  # ['Tripta_CreateFerrule', 'Tripta_CreateGasket']
+```
+
+## 🧪 Tests
+- ``tests/test_workbench.py`` valida la inicialización del workbench,
+  la existencia de los comandos y la generación de modelos de ejemplo.
+
+## 🔮 Próximos Pasos
+- Integrar con la API real de FreeCAD y registrar los comandos mediante
+  ``Gui.addCommand``.
+- Añadir menús contextuales sobre objetos dentro del árbol de FreeCAD.
+- Preparar empaquetado para distribución vía Addon Manager.
+
+---
+**Documento generado:** 18 de Agosto 2025

--- a/resources/triptafittings.svg
+++ b/resources/triptafittings.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#4a90e2"/>
+  <circle cx="32" cy="32" r="20" fill="#fff"/>
+</svg>

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Tests para la integración del workbench del Sprint 4."""
+import os
+import sys
+
+# Asegurar que la ruta raíz esté en ``sys.path`` para las importaciones
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import InitGui
+import TriptaFittingsCmd
+import TriptaFittingsGui
+
+
+def test_workbench_initialization():
+    wb = InitGui.TriptaFittingsWorkbench()
+    cmds = wb.Initialize()
+    assert "Tripta_CreateFerrule" in cmds
+    assert "Tripta_CreateGasket" in cmds
+    assert wb.Icon == TriptaFittingsGui.WB_ICON
+    assert wb.GetClassName() == "Gui::PythonWorkbench"
+
+
+def test_commands_resources_and_activation():
+    ferrule_cmd = TriptaFittingsCmd.COMMANDS["Tripta_CreateFerrule"]
+    gasket_cmd = TriptaFittingsCmd.COMMANDS["Tripta_CreateGasket"]
+
+    # Verificar recursos de los comandos
+    res_f = ferrule_cmd.GetResources()
+    res_g = gasket_cmd.GetResources()
+    for res in (res_f, res_g):
+        assert os.path.exists(res["Pixmap"])
+        assert "MenuText" in res and "ToolTip" in res
+
+    # Activar comando y comprobar modelo generado
+    model = ferrule_cmd.Activated()
+    assert model["name"] == "Ferrule_3.0in_DN80"
+    model = gasket_cmd.Activated()
+    assert model["name"] == "Gasket_3.0in_DN80"
+
+
+def test_gui_module_lists_commands_and_icon():
+    assert TriptaFittingsGui.WB_ICON.endswith(".svg")
+    assert os.path.exists(TriptaFittingsGui.WB_ICON)
+    toolbar_cmds = TriptaFittingsGui.list_toolbar_commands()
+    assert toolbar_cmds == ["Tripta_CreateFerrule", "Tripta_CreateGasket"]


### PR DESCRIPTION
## Summary
- scaffold TriptaFittings workbench with initialization hooks
- add ferrule and gasket creation commands and shared GUI helpers
- document sprint 4 workbench integration and include placeholder icon

## Testing
- `pytest -q`


