### PR TITLE
feat: add session model manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Generador automático de modelos paramétricos de **Ferrule (Férula)** y **Gask
 - ✅ **Integración nativa** con FreeCAD
 - ✅ **Spreadsheets automáticas** con parámetros
 - ✅ **Exportación** a formatos estándar (STEP, IGES, STL)
+- ✅ **Gestión básica** de modelos generados en sesión
 
 ## 📋 Requisitos
 

--- a/docs/sprint5_technical_docs.md
+++ b/docs/sprint5_technical_docs.md
@@ -1,0 +1,45 @@
+# Sprint 5: Funcionalidades Avanzadas - Documentación Técnica
+
+## 📋 Resumen Ejecutivo
+El **Sprint 5** incorpora un gestor de modelos en memoria que permite
+administrar las geometrías generadas durante una sesión.  Se amplían los
+ generadores de ``Ferrule`` y ``Gasket`` para etiquetar cada modelo con su
+tipo, habilitando filtrados y operaciones de limpieza.
+
+## 🏗️ Componentes Implementados
+
+### `ui/model_manager.py`
+- Clase ``ModelManager`` para registrar modelos generados.
+- Métodos para agregar, listar, eliminar y limpiar modelos por
+  componente.
+
+### `models/ferrule_generator.py` y `models/gasket_generator.py`
+- Añaden el campo ``component`` en la geometría generada para facilitar
+  la gestión posterior.
+
+### `ui/user_interface.py`
+- Integra ``ModelManager`` y expone métodos ``list_generated_models``,
+  ``remove_model`` y ``clear_models``.
+
+## 🔧 Ejemplo de Uso
+```python
+from ui.user_interface import UserInterface
+
+ui = UserInterface()
+ui.generate_model('ferrule', 3.0)
+models = ui.list_generated_models()
+print(models[0]['component'])  # 'ferrule'
+ui.clear_models()
+```
+
+## 🧪 Tests
+- ``tests/test_model_manager.py`` valida el flujo completo de gestión de
+  modelos: registro, filtrado, eliminación y limpieza.
+
+## 🔮 Próximos Pasos
+- Implementar exportación a formatos STEP/IGES/STL.
+- Añadir panel de depuración con logging avanzado.
+- Gestionar grupos y operaciones masivas de modelos.
+
+---
+**Documento generado:** 18 de Agosto 2025

--- a/models/ferrule_generator.py
+++ b/models/ferrule_generator.py
@@ -39,6 +39,7 @@ class FerruleGenerator:
         return {
             "name": self.preset.get_name(),
             "parameters": self.preset.get_parameters_dict(),
+            "component": "ferrule",
         }
 
     def update_spreadsheet(self, spreadsheet: Dict[str, Any]) -> None:

--- a/models/gasket_generator.py
+++ b/models/gasket_generator.py
@@ -37,6 +37,7 @@ class GasketGenerator:
         return {
             "name": self.preset.get_name(),
             "parameters": self.preset.get_parameters_dict(),
+            "component": "gasket",
         }
 
     def update_spreadsheet(self, spreadsheet: Dict[str, Any]) -> None:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Tests para la gestión de modelos generados (Sprint 5)."""
+import os
+import sys
+
+# Añadir ruta raíz para importaciones
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ui.user_interface import UserInterface
+
+
+def test_model_management_flow():
+    ui = UserInterface()
+
+    ferrule = ui.generate_model('ferrule', 3.0)
+    gasket = ui.generate_model('gasket', 3.0)
+
+    # Listar todos los modelos
+    all_models = ui.list_generated_models()
+    assert len(all_models) == 2
+
+    # Filtrar por componente
+    only_ferrules = ui.list_generated_models('ferrule')
+    assert [m['name'] for m in only_ferrules] == [ferrule['name']]
+
+    # Eliminar por nombre
+    assert ui.remove_model(ferrule['name']) is True
+    remaining = ui.list_generated_models()
+    assert len(remaining) == 1 and remaining[0]['name'] == gasket['name']
+
+    # Limpiar todos los modelos
+    ui.clear_models()
+    assert ui.list_generated_models() == []

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,2 +1,7 @@
 # -*- coding: utf-8 -*-
 """Paquete de interfaz de usuario para TriptaFittings."""
+
+from .user_interface import UserInterface
+from .model_manager import ModelManager
+
+__all__ = ["UserInterface", "ModelManager"]

--- a/ui/model_manager.py
+++ b/ui/model_manager.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Gestor sencillo de modelos generados.
+
+Este módulo mantiene un registro en memoria de los modelos generados
+ durante una sesión.  Permite listarlos, eliminarlos individualmente o
+ limpiar grupos completos según su tipo de componente.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Any, Optional
+
+
+class ModelManager:
+    """Gestiona los modelos generados en una sesión."""
+
+    def __init__(self) -> None:
+        # Diccionario indexado por nombre de modelo
+        self._models: Dict[str, Dict[str, Any]] = {}
+
+    def add_model(self, model: Dict[str, Any]) -> str:
+        """Agrega un modelo al gestor.
+
+        Parameters
+        ----------
+        model: Dict[str, Any]
+            Estructura que representa al modelo.  Debe contener las claves
+            ``name`` y ``component``.
+
+        Returns
+        -------
+        str
+            Nombre con el que se almacenó el modelo.
+        """
+        name = model.get("name")
+        if not name:
+            raise ValueError("El modelo debe contener un nombre")
+        if "component" not in model:
+            raise ValueError("El modelo debe indicar su componente")
+        self._models[name] = model
+        return name
+
+    def list_models(self, component: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Lista los modelos almacenados.
+
+        Parameters
+        ----------
+        component: Optional[str]
+            Filtra por tipo de componente (ej. ``"ferrule"`` o ``"gasket"``).
+        """
+        if component is None:
+            return list(self._models.values())
+        return [m for m in self._models.values() if m.get("component") == component]
+
+    def remove_model(self, name: str) -> bool:
+        """Elimina un modelo por nombre.
+
+        Returns
+        -------
+        bool
+            ``True`` si el modelo existía y fue eliminado.
+        """
+        return self._models.pop(name, None) is not None
+
+    def clear(self, component: Optional[str] = None) -> None:
+        """Elimina todos los modelos o solo los de cierto componente."""
+        if component is None:
+            self._models.clear()
+        else:
+            to_delete = [k for k, v in self._models.items() if v.get("component") == component]
+            for key in to_delete:
+                del self._models[key]

--- a/ui/user_interface.py
+++ b/ui/user_interface.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 from models.data_manager import DataManager
 from models.ferrule_generator import FerruleGenerator
 from models.gasket_generator import GasketGenerator
+from .model_manager import ModelManager
 
 
 class UserInterface:
@@ -25,6 +26,8 @@ class UserInterface:
 
     def __init__(self, data_directory: Optional[str] = None) -> None:
         self._manager = DataManager(data_directory)
+        # Gestor de modelos generados en la sesión
+        self._models = ModelManager()
         # Cargar todos los datos al inicializar la interfaz.
         self._manager.load_all_data()
 
@@ -68,4 +71,20 @@ class UserInterface:
         else:  # pragma: no cover - validación redundante
             raise ValueError(f"Tipo de componente inválido: {component}")
 
-        return generator.generate_geometry()
+        model = generator.generate_geometry()
+        # Registrar modelo generado para su gestión posterior
+        self._models.add_model(model)
+        return model
+
+    # --- Gestión de modelos -------------------------------------------------
+    def list_generated_models(self, component: str | None = None) -> List[Dict[str, Any]]:
+        """Retorna los modelos generados en la sesión actual."""
+        return self._models.list_models(component)
+
+    def remove_model(self, name: str) -> bool:
+        """Elimina un modelo por nombre."""
+        return self._models.remove_model(name)
+
+    def clear_models(self, component: str | None = None) -> None:
+        """Elimina todos los modelos o solo los del componente indicado."""
+        self._models.clear(component)


### PR DESCRIPTION
## Summary
- add `ModelManager` to keep track of generated models in session
- tag geometry with component type for better filtering
- document Sprint 5 advanced features and provide tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40ab71744832188edcda366b3ccc4